### PR TITLE
fix(web-lib): fix eslint no-unused-vars in ts files

### DIFF
--- a/configs/eslint-react/library.js
+++ b/configs/eslint-react/library.js
@@ -1,10 +1,15 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { resolve } = require('node:path');
 
 const project = resolve(process.cwd(), 'tsconfig.json');
 
 /** @type {import("eslint").Linter.Config} */
 module.exports = {
-  extends: ['eslint:recommended', 'prettier'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
   globals: {
     React: true,
     JSX: true,

--- a/configs/eslint-react/next.js
+++ b/configs/eslint-react/next.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { resolve } = require('node:path');
 
 const project = resolve(process.cwd(), 'tsconfig.json');
@@ -6,6 +7,7 @@ const project = resolve(process.cwd(), 'tsconfig.json');
 module.exports = {
   extends: [
     'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
     'prettier',
     require.resolve('@vercel/style-guide/eslint/next'),
   ],

--- a/packages/web-lib/src/animation/fps/Index.ts
+++ b/packages/web-lib/src/animation/fps/Index.ts
@@ -9,7 +9,7 @@ function getFPS(callback: (fps: number) => void) {
   let frames = 0;
   let open = true;
   requestAnimationFrame(function loop() {
-    let now = +new Date();
+    const now = +new Date();
     frames++;
     if (now > prevTime + 1000) {
       const fps = Math.round((frames * 1000) / (now - prevTime));


### PR DESCRIPTION
enable ts-eslint-recommended to fix eslint no-unused-vars in ts files